### PR TITLE
Fix/attributes coherence

### DIFF
--- a/zcollection/collection/tests/test_collection.py
+++ b/zcollection/collection/tests/test_collection.py
@@ -548,8 +548,7 @@ def test_insert_validation(
     arg,
     request,
 ):
-    """Test the insertion of a dataset with metadata validation.
-    """
+    """Test the insertion of a dataset with metadata validation."""
     tested_fs = request.getfixturevalue(arg)
     ds = next(create_test_dataset_with_fillvalue())
 

--- a/zcollection/collection/tests/test_collection.py
+++ b/zcollection/collection/tests/test_collection.py
@@ -543,6 +543,47 @@ def test_insert_failed(
 
 
 @pytest.mark.parametrize('arg', ['local_fs', 's3_fs'])
+def test_insert_validation(
+    dask_client,  # pylint: disable=redefined-outer-name,unused-argument
+    arg,
+    request,
+):
+    """Test the insertion of a dataset with metadata validation.
+    """
+    tested_fs = request.getfixturevalue(arg)
+    ds = next(create_test_dataset_with_fillvalue())
+
+    zcollection = convenience.create_collection(
+        axis='time',
+        ds=ds,
+        partition_handler=partitioning.Date(('time', ), 'M'),
+        partition_base_dir=str(tested_fs.collection),
+        filesystem=tested_fs.fs)
+    zcollection.insert(ds, merge_callable=merging.merge_time_series)
+
+    ds = next(create_test_dataset_with_fillvalue())
+
+    # Inserting a dataset containing valid attributes
+    zcollection.insert(ds, validate=True)
+
+    # Inserting a dataset containing an invalid attributes
+    ds = next(create_test_dataset_with_fillvalue())
+    ds.attrs = (meta.Attribute('invalid', 1), )
+
+    with pytest.raises(ValueError):
+        zcollection.insert(ds, validate=True)
+
+    # Inserting a dataset containing variables with invalid attributes
+    ds = next(create_test_dataset_with_fillvalue())
+
+    for var in ds.variables.values():
+        var.attrs = (meta.Attribute('invalid', 1), )
+
+    with pytest.raises(ValueError):
+        zcollection.insert(ds, validate=True)
+
+
+@pytest.mark.parametrize('arg', ['local_fs', 's3_fs'])
 def test_map_partition(
     dask_client,  # pylint: disable=redefined-outer-name,unused-argument
     arg,

--- a/zcollection/dataset.py
+++ b/zcollection/dataset.py
@@ -358,8 +358,8 @@ class Dataset:
         Args:
             ds: Dataset metadata.
         """
-        self.attrs = ds.attrs
-        [
+        self.attrs = tuple(ds.attrs)
+        _ = [
             var.fill_attrs(ds.variables[name])
             for name, var in self.variables.items()
         ]

--- a/zcollection/partitioning/abc.py
+++ b/zcollection/partitioning/abc.py
@@ -141,10 +141,6 @@ def list_partitions(
     if depth == -1:
         return StopIteration()
 
-    if depth == 0:
-        yield from sorted(fs.ls(path, detail=False))
-        return StopIteration()
-
     if root:
         folders = map(
             lambda info: info['name'].rstrip('/'),
@@ -154,12 +150,20 @@ def list_partitions(
                 fs.ls(path, detail=True),
             ),
         )
+        # If we're partitioning at top level (example: by year)
+        if depth == 0:
+            yield from sorted(folders)
+            return StopIteration()
 
         for pathname in sorted(folders):
             yield from list_partitions(fs,
                                        pathname,
                                        depth=depth - 1,
                                        root=False)
+        return StopIteration()
+
+    if depth == 0:
+        yield from sorted(fs.ls(path, detail=False))
         return StopIteration()
 
     for item in sorted(fs.ls(path, detail=False)):

--- a/zcollection/partitioning/tests/test_date.py
+++ b/zcollection/partitioning/tests/test_date.py
@@ -193,12 +193,12 @@ def test_values_must_be_datetime64(
 
 
 @pytest.mark.parametrize(
-    "start, end, step, xyz",
+    'start, end, step, path_generator',
     [(('2000-01-01', 'D'), ('2000-02-01', 'D'), (1, 'D'), lambda item:
       (f'year={item.year}', f'month={item.month:02d}', f'day={item.day:02d}')),
      (('2000', 'Y'), ('2005', 'Y'), (1, 'Y'), lambda item:
       (f'year={item.year}', ))])
-def test_listing_partition(tmpdir, start, end, step, xyz):
+def test_listing_partition(tmpdir, start, end, step, path_generator):
     """Test the listing of the partitions."""
     fs = fsspec.filesystem('memory')
     variables = [
@@ -314,7 +314,7 @@ def test_listing_partition(tmpdir, start, end, step, xyz):
     expected = []
     for date in numpy.arange(start, end, step):
         item = date.item()
-        partition = fs.sep.join((root, *xyz(item)))
+        partition = fs.sep.join((root, *path_generator(item)))
         expected.append(partition)
         fs.mkdirs(partition)
 

--- a/zcollection/partitioning/tests/test_date.py
+++ b/zcollection/partitioning/tests/test_date.py
@@ -192,7 +192,13 @@ def test_values_must_be_datetime64(
     # pylint: enable=protected-access
 
 
-def test_listing_partition():
+@pytest.mark.parametrize(
+    "start, end, step, xyz",
+    [(('2000-01-01', 'D'), ('2000-02-01', 'D'), (1, 'D'), lambda item:
+      (f'year={item.year}', f'month={item.month:02d}', f'day={item.day:02d}')),
+     (('2000', 'Y'), ('2005', 'Y'), (1, 'Y'), lambda item:
+      (f'year={item.year}', ))])
+def test_listing_partition(tmpdir, start, end, step, xyz):
     """Test the listing of the partitions."""
     fs = fsspec.filesystem('memory')
     variables = [
@@ -295,29 +301,27 @@ def test_listing_partition():
         'wind_speed_rad',
         'x_factor',
     ]
-    start = numpy.datetime64('2000-01-01', 'D')
-    end = numpy.datetime64('2000-02-01', 'D')
-    delta = numpy.timedelta64(1, 'D')
-
-    root = '/zcollection'
+    root = f'{tmpdir}/zcollection'
     fs.mkdir(root)
     fs.open(fs.sep.join((root, '.zcollection')), 'w').close()
 
+    partitioning = Date(('dates', ), step[1])
+
+    start = numpy.datetime64(*start)
+    end = numpy.datetime64(*end)
+    step = numpy.timedelta64(*step)
+
     expected = []
-    for date in numpy.arange(start, end, delta):
+    for date in numpy.arange(start, end, step):
         item = date.item()
-        partition = fs.sep.join(
-            (root, f'year={item.year}', f'month={item.month:02d}',
-             f'day={item.day:02d}'))
+        partition = fs.sep.join((root, *xyz(item)))
         expected.append(partition)
         fs.mkdirs(partition)
 
         _ = {fs.mkdirs(fs.sep.join((partition, item))) for item in variables}
-
         _ = {
             fs.open(fs.sep.join((partition, item)), 'w').close()
             for item in ['.zattrs', '.zgroup', '.zmetadata']
         }
 
-    partitioning = Date(('dates', ), 'D')
     assert expected == list(partitioning.list_partitions(fs, root))

--- a/zcollection/variable.py
+++ b/zcollection/variable.py
@@ -505,6 +505,23 @@ class Variable:
             raise ValueError('data shape does not match variable dimensions')
         return result
 
+    def set_for_insertion(self) -> Variable:
+        """Create a new variable without any attribute.
+
+        Returns:
+            The variable.
+        """
+        return _new_variable(self.name, self.array, self.dimensions, tuple(),
+                             self.compressor, self.fill_value, self.filters)
+
+    def fill_attrs(self, var: meta.Variable):
+        """Fill the variable attributes using the provided metadata.
+
+        Args:
+            var: Variable's metadata.
+        """
+        self.attrs = var.attrs
+
     def rename(self, name: str) -> Variable:
         """Rename the variable.
 


### PR DESCRIPTION
- Storing dataset and variables attributes in .zcollection only
  - Attributes are removed at insertion
  - Attributes are restored at load
- Fixing partitions listing for top level type partitioning

test_collection/test_insert_failed now fails, it might be due to a caching problem.