### PR TITLE
feat: lower minimum Python from 3.14 to 3.12

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.14']
+        python-version: ['3.12', '3.13', '3.14']
     steps:
     - name: Checkout
       uses: actions/checkout@v4
@@ -75,7 +75,7 @@ jobs:
           channels:
             - conda-forge
         create-args: |
-          python=3.14
+          python=3.12
         environment-name: ZCollection
         environment-file: conda/environment.yml
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -54,7 +54,7 @@ jobs:
             channels:
               - conda-forge
           create-args: |
-            python=3.14
+            python=3.12
           environment-name: ZCollection
           environment-file: conda/environment.yml
 

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,5 +11,5 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
       with:
-        python-version: '3.14'
+        python-version: '3.12'
     - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/pypipublish.yaml
+++ b/.github/workflows/pypipublish.yaml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.14'
+          python-version: '3.12'
 
       - name: Install build tooling
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: "v3.21.2"
     hooks:
     - id: pyupgrade
-      args: [--py314-plus]
+      args: [--py312-plus]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
     hooks:

--- a/conda/environment.yml
+++ b/conda/environment.yml
@@ -2,8 +2,8 @@ name: ZCollection
 channels:
   - conda-forge
 dependencies:
-  # Python (matches setup.cfg `python_requires = >=3.14`)
-  - python >=3.14
+  # Python (matches setup.cfg `python_requires = >=3.12`)
+  - python >=3.12
   # Runtime
   - dask-core >=2022.8.0
   - distributed

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -8,7 +8,7 @@ compatibility runtime.
 Requirements
 ------------
 
-- Python **3.14** or later
+- Python **3.12** or later
 - `zarr <https://zarr.readthedocs.io/>`_ ≥ 3.1.6
 - `numpy <https://numpy.org/>`_ ≥ 1.20
 - `numcodecs <https://numcodecs.readthedocs.io/>`_ ≥ 0.13

--- a/examples/ex_netcdf_to_zcollection.py
+++ b/examples/ex_netcdf_to_zcollection.py
@@ -98,6 +98,8 @@ This example uses the ``netCDF4`` library to access nested groups,
 which xarray cannot do natively without an explicit ``group=`` argument.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 import argparse
 from datetime import datetime

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ __version__ = "{version}"
 
 
 [tool.ruff]
-target-version = "py314"
+target-version = "py312"
 line-length = 80
 
 [tool.ruff.lint.pycodestyle]

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,6 +8,8 @@ classifiers =
     Operating System :: MacOS
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: 3.14
     Topic :: Scientific/Engineering :: Physics
 description = Zarr Collection
@@ -34,7 +36,7 @@ install_requires =
 package_dir =
     = .
 packages = find:
-python_requires = >=3.14
+python_requires = >=3.12
 zip_safe = False
 
 [options.extras_require]
@@ -78,3 +80,4 @@ ignore =
 [mypy]
 ignore_missing_imports=True
 exclude=tests
+python_version=3.12

--- a/zcollection/aio.py
+++ b/zcollection/aio.py
@@ -9,6 +9,8 @@ module is the recommended surface when running inside an event loop (e.g.
 FastAPI handlers, Jupyter ``%await`` cells, or other async workloads).
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from .collection import Collection

--- a/zcollection/api.py
+++ b/zcollection/api.py
@@ -4,6 +4,8 @@
 # BSD-style license that can be found in the LICENSE file.
 """Public sync facade for zcollection."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 from .collection import Collection

--- a/zcollection/benches/probe.py
+++ b/zcollection/benches/probe.py
@@ -10,6 +10,8 @@ counters whenever the underlying store is exercised. It uses
 (local, obstore, memory) and never changes data semantics.
 """
 
+from __future__ import annotations
+
 from typing import Any
 from collections import Counter
 

--- a/zcollection/codecs/defaults.py
+++ b/zcollection/codecs/defaults.py
@@ -17,6 +17,8 @@ translates these into ``zarr.codecs`` objects at write time via
 :func:`resolve_codec`.
 """
 
+from __future__ import annotations
+
 from typing import Any
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass

--- a/zcollection/codecs/sharding.py
+++ b/zcollection/codecs/sharding.py
@@ -21,6 +21,8 @@ doubled. This keeps growth tracking the array's existing aspect ratio
 is the natural growth direction.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 import math
 

--- a/zcollection/collection/base.py
+++ b/zcollection/collection/base.py
@@ -33,6 +33,8 @@ and :func:`zcollection.open_collection`; this module's
 their direct backers.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 import asyncio
 from collections.abc import Callable, Iterable, Iterator

--- a/zcollection/dask/runner.py
+++ b/zcollection/dask/runner.py
@@ -28,7 +28,7 @@ def _try_get_client() -> Any | None:
         return None
     try:
         return get_client()
-    except ValueError, RuntimeError:
+    except (ValueError, RuntimeError):
         return None
 
 

--- a/zcollection/data/_repr.py
+++ b/zcollection/data/_repr.py
@@ -9,6 +9,8 @@ size for the dataset, each child group, and each variable so the user can
 gauge memory/disk footprint at a glance.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 from collections.abc import Iterable, Iterator
 

--- a/zcollection/data/dataset.py
+++ b/zcollection/data/dataset.py
@@ -18,6 +18,8 @@ round-tripping). On top of plain :class:`Group` semantics it adds:
   builds a flat dataset, since xarray has no native group concept).
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 from collections import OrderedDict
 from collections.abc import Iterable, Mapping

--- a/zcollection/data/group.py
+++ b/zcollection/data/group.py
@@ -17,6 +17,8 @@ absolute (``/data_01/ku``) and relative (``data_01/ku``) forms. Short
 names address direct children; paths walk down through nested groups.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 from collections import OrderedDict
 from collections.abc import Iterable, Iterator, Mapping

--- a/zcollection/data/variable.py
+++ b/zcollection/data/variable.py
@@ -11,6 +11,8 @@ backend. The :attr:`Variable.is_lazy` flag is true iff the underlying
 array isn't a plain :class:`numpy.ndarray`.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 import math
 

--- a/zcollection/indexing/parquet.py
+++ b/zcollection/indexing/parquet.py
@@ -13,6 +13,8 @@ Querying with a dict of equality filters yields a ``{partition: [(start,
 stop), ...]}`` mapping that callers feed to per-partition slicing.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 from collections.abc import Callable, Iterable
 

--- a/zcollection/io/async_partition.py
+++ b/zcollection/io/async_partition.py
@@ -9,6 +9,8 @@ end-to-end so that callers can run many partition reads/writes concurrently
 on a single event loop.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 import asyncio
 from collections.abc import Iterable

--- a/zcollection/io/immutable.py
+++ b/zcollection/io/immutable.py
@@ -15,6 +15,8 @@ under the matching nested path (e.g. an immutable variable at
 ``/data_01/ku/range`` is written to ``_immutable/data_01/ku/range``).
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 from collections.abc import Iterable
 import logging

--- a/zcollection/io/partition.py
+++ b/zcollection/io/partition.py
@@ -4,6 +4,8 @@
 # BSD-style license that can be found in the LICENSE file.
 """Per-partition Zarr v3 group I/O — synchronous path."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 from collections.abc import Iterable
 import logging

--- a/zcollection/io/root.py
+++ b/zcollection/io/root.py
@@ -4,6 +4,8 @@
 # BSD-style license that can be found in the LICENSE file.
 """Read/write the ``_zcollection.json`` root config."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 
 from ..errors import CollectionNotFoundError

--- a/zcollection/partitioning/base.py
+++ b/zcollection/partitioning/base.py
@@ -4,6 +4,8 @@
 # BSD-style license that can be found in the LICENSE file.
 """Partitioning Protocol — pure-numpy partition key extraction."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Protocol, runtime_checkable
 from collections.abc import Iterable, Iterator
 

--- a/zcollection/partitioning/catalog.py
+++ b/zcollection/partitioning/catalog.py
@@ -27,6 +27,8 @@ Two-phase / crash safety:
   back to walking. :func:`reconcile` performs the recovery write-back.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 from dataclasses import dataclass
 import hashlib
@@ -95,7 +97,7 @@ class Catalog:
             return None
         try:
             doc = json.loads(raw.decode("utf-8"))
-        except json.JSONDecodeError, UnicodeDecodeError:
+        except (json.JSONDecodeError, UnicodeDecodeError):
             # Treat a corrupted catalog as missing; callers will rebuild.
             return None
         paths = tuple(doc.get("paths", ()))

--- a/zcollection/partitioning/date.py
+++ b/zcollection/partitioning/date.py
@@ -4,6 +4,8 @@
 # BSD-style license that can be found in the LICENSE file.
 """Date partitioning — bucket a datetime64 axis by Y/M/D/h/m/s."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 from collections.abc import Iterator
 

--- a/zcollection/partitioning/grouped.py
+++ b/zcollection/partitioning/grouped.py
@@ -8,6 +8,8 @@ Useful when, e.g., altimetry passes 1..100 should all live in one partition
 rather than producing 100 partitions per cycle.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 from collections.abc import Iterator
 

--- a/zcollection/partitioning/sequence.py
+++ b/zcollection/partitioning/sequence.py
@@ -4,6 +4,8 @@
 # BSD-style license that can be found in the LICENSE file.
 """Sequence partitioning — one partition per unique value tuple."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 from collections.abc import Iterator
 

--- a/zcollection/schema/builder.py
+++ b/zcollection/schema/builder.py
@@ -33,6 +33,8 @@ Hierarchical groups can be declared by passing ``group=`` to
     )
 """
 
+from __future__ import annotations
+
 from typing import Any
 from collections.abc import Iterable
 

--- a/zcollection/schema/dataset.py
+++ b/zcollection/schema/dataset.py
@@ -4,6 +4,8 @@
 # BSD-style license that can be found in the LICENSE file.
 """Dataset-level schema (root :class:`GroupSchema`)."""
 
+from __future__ import annotations
+
 from typing import Any
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -15,7 +17,10 @@ from .variable import VariableSchema
 from .versioning import FORMAT_VERSION, upgrade
 
 
-@dataclass(frozen=True, slots=True)
+# No ``slots=True``: it rebuilds the class, which breaks zero-arg ``super()``
+# on Python 3.12 (CPython gh-90562, fixed in 3.13). Cheap to forgo here --
+# this is the root schema, instantiated about once per collection.
+@dataclass(frozen=True)
 class DatasetSchema(GroupSchema):
     """Immutable description of a collection's dataset.
 

--- a/zcollection/schema/dimension.py
+++ b/zcollection/schema/dimension.py
@@ -4,6 +4,8 @@
 # BSD-style license that can be found in the LICENSE file.
 """Dimension metadata."""
 
+from __future__ import annotations
+
 from typing import Any
 from dataclasses import dataclass
 

--- a/zcollection/schema/group.py
+++ b/zcollection/schema/group.py
@@ -10,6 +10,8 @@ the root group is a :class:`~zcollection.schema.DatasetSchema`; every nested
 group is a plain :class:`GroupSchema`.
 """
 
+from __future__ import annotations
+
 from typing import Any
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass, field

--- a/zcollection/schema/serde.py
+++ b/zcollection/schema/serde.py
@@ -9,6 +9,8 @@ JSON schema for that file. Per-partition Zarr v3 metadata (``zarr.json``) is
 written by the io layer.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 import json
 

--- a/zcollection/schema/variable.py
+++ b/zcollection/schema/variable.py
@@ -4,6 +4,8 @@
 # BSD-style license that can be found in the LICENSE file.
 """Variable metadata: dtype, dims, fill, codec stack, role."""
 
+from __future__ import annotations
+
 from typing import Any
 from dataclasses import dataclass, field
 from enum import StrEnum

--- a/zcollection/store/factory.py
+++ b/zcollection/store/factory.py
@@ -4,6 +4,8 @@
 # BSD-style license that can be found in the LICENSE file.
 """URL-driven store factory."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 from urllib.request import url2pathname

--- a/zcollection/store/icechunk_store.py
+++ b/zcollection/store/icechunk_store.py
@@ -18,6 +18,8 @@ under :data:`META_DIR`. From the caller's perspective the
 :meth:`read_bytes` / :meth:`write_bytes` API is unchanged.
 """
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -220,7 +222,7 @@ class IcechunkStore(Store):
             return None
         try:
             doc = json.loads(bytes(buf.to_bytes()).decode("utf-8"))
-        except UnicodeDecodeError, json.JSONDecodeError:
+        except (UnicodeDecodeError, json.JSONDecodeError):
             return None
         payload = doc.get("attributes", {}).get(_PAYLOAD_ATTR)
         return payload.encode("utf-8") if isinstance(payload, str) else None

--- a/zcollection/types.py
+++ b/zcollection/types.py
@@ -4,6 +4,8 @@
 # BSD-style license that can be found in the LICENSE file.
 """Public type aliases and protocols."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any, Protocol, TypeAlias
 from collections.abc import Callable
 

--- a/zcollection/view/base.py
+++ b/zcollection/view/base.py
@@ -4,6 +4,8 @@
 # BSD-style license that can be found in the LICENSE file.
 """Slim, v3-native View implementation."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Any
 import asyncio
 from collections.abc import Callable, Iterable, Iterator


### PR DESCRIPTION
Three 3.14-only constructs prevented importing on 3.12/3.13:

- unparenthesized `except A, B:` (PEP 758) -> parenthesized (3 sites)
- eagerly-evaluated annotations (PEP 649) -> `from __future__ import annotations` in the 31 modules that need it
- zero-arg `super()` in a `slots=True` dataclass (CPython gh-90562, fixed in 3.13) -> drop `slots=True` on DatasetSchema

CI matrix now 3.12/3.13/3.14; mypy pinned to `python_version=3.12`.